### PR TITLE
Example of adding a new 'brrr' statement to Python.

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -376,6 +376,14 @@ while_stmt[stmt_ty]:
     | invalid_while_stmt
     | 'while' a=named_expression ':' b=block c=[else_block] { _PyAST_While(a, b, c, EXTRA) }
 
+
+# brrr block
+# ---------------
+
+brrr_stmt[stmt_ty]:
+    | invalid_brrr_stmt
+    | 'brrr' ':' b=block { _PyAST_Brrr(b, EXTRA) }
+
 # For statement
 # -------------
 
@@ -1359,6 +1367,9 @@ invalid_class_pattern:
         "positional patterns follow keyword patterns") }
 invalid_class_argument_pattern[asdl_pattern_seq*]:
     | [positional_patterns ','] keyword_patterns ',' a=positional_patterns { a }
+invalid_brrr_stmt:
+    | a='brrr' ':' NEWLINE !INDENT {
+        RAISE_INDENTATION_ERROR("expected an indented block after 'brrr' statement on line %d", a->lineno) }
 invalid_if_stmt:
     | 'if' named_expression NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }
     | a='if' a=named_expression ':' NEWLINE !INDENT {

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -382,7 +382,7 @@ while_stmt[stmt_ty]:
 
 brrr_stmt[stmt_ty]:
     | invalid_brrr_stmt
-    | 'brrr' ':' b=block { _PyAST_Brrr(b, EXTRA) }
+    | 'brrr' &&':' b=block { _PyAST_Brrr(b, EXTRA) }
 
 # For statement
 # -------------

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -192,7 +192,7 @@ enum _stmt_kind {FunctionDef_kind=1, AsyncFunctionDef_kind=2, ClassDef_kind=3,
                   Raise_kind=17, Try_kind=18, TryStar_kind=19, Assert_kind=20,
                   Import_kind=21, ImportFrom_kind=22, Global_kind=23,
                   Nonlocal_kind=24, Expr_kind=25, Pass_kind=26, Break_kind=27,
-                  Continue_kind=28};
+                  Continue_kind=28, Brrr_kind=29};
 struct _stmt {
     enum _stmt_kind kind;
     union {
@@ -314,6 +314,10 @@ struct _stmt {
             asdl_stmt_seq *orelse;
             asdl_stmt_seq *finalbody;
         } Try;
+
+        struct {
+            asdl_stmt_seq *body;
+        } Brrr;
 
         struct {
             asdl_stmt_seq *body;

--- a/Include/internal/pycore_ast.h
+++ b/Include/internal/pycore_ast.h
@@ -732,6 +732,9 @@ stmt_ty _PyAST_While(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq *
 stmt_ty _PyAST_If(expr_ty test, asdl_stmt_seq * body, asdl_stmt_seq * orelse,
                   int lineno, int col_offset, int end_lineno, int
                   end_col_offset, PyArena *arena);
+stmt_ty _PyAST_Brrr(asdl_stmt_seq * body,
+                  int lineno, int col_offset, int end_lineno, int
+                  end_col_offset, PyArena *arena);
 stmt_ty _PyAST_With(asdl_withitem_seq * items, asdl_stmt_seq * body, string
                     type_comment, int lineno, int col_offset, int end_lineno,
                     int end_col_offset, PyArena *arena);

--- a/Include/internal/pycore_ast_state.h
+++ b/Include/internal/pycore_ast_state.h
@@ -70,6 +70,7 @@ struct ast_state {
     PyObject *Gt_type;
     PyObject *IfExp_type;
     PyObject *If_type;
+    PyObject *Brrr_type;
     PyObject *ImportFrom_type;
     PyObject *Import_type;
     PyObject *In_singleton;
@@ -201,6 +202,7 @@ struct ast_state {
     PyObject *handlers;
     PyObject *id;
     PyObject *ifs;
+    PyObject *brrs;
     PyObject *is_async;
     PyObject *items;
     PyObject *iter;

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -35,6 +35,7 @@ module Python
           | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
           | While(expr test, stmt* body, stmt* orelse)
           | If(expr test, stmt* body, stmt* orelse)
+          | Brrr(stmt* body)
           | With(withitem* items, stmt* body, string? type_comment)
           | AsyncWith(withitem* items, stmt* body, string? type_comment)
 

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -43,6 +43,7 @@ static KeywordToken *reserved_keywords[] = {
         {"with", 634},
         {"elif", 663},
         {"else", 664},
+        {"brrr", 665},
         {"None", 614},
         {"True", 613},
         {NULL, -1},
@@ -620,6 +621,7 @@ static char *soft_keywords[] = {
 #define _tmp_287_type 1533
 #define _tmp_288_type 1534
 #define _tmp_289_type 1535
+#define brrr_stmt_type 1536
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -683,6 +685,7 @@ static excepthandler_ty except_block_rule(Parser *p);
 static excepthandler_ty except_star_block_rule(Parser *p);
 static asdl_stmt_seq* finally_block_rule(Parser *p);
 static stmt_ty match_stmt_rule(Parser *p);
+static stmt_ty brrr_stmt_rule(Parser *p);
 static expr_ty subject_expr_rule(Parser *p);
 static match_case_ty case_block_rule(Parser *p);
 static expr_ty guard_rule(Parser *p);
@@ -855,6 +858,7 @@ static void *invalid_as_pattern_rule(Parser *p);
 static void *invalid_class_pattern_rule(Parser *p);
 static asdl_pattern_seq* invalid_class_argument_pattern_rule(Parser *p);
 static void *invalid_if_stmt_rule(Parser *p);
+static void *invalid_brrr_stmt_rule(Parser *p);
 static void *invalid_elif_stmt_rule(Parser *p);
 static void *invalid_else_stmt_rule(Parser *p);
 static void *invalid_while_stmt_rule(Parser *p);
@@ -2069,6 +2073,7 @@ simple_stmt_rule(Parser *p)
 //     | invalid_compound_stmt
 //     | &('def' | '@' | 'async') function_def
 //     | &'if' if_stmt
+//     | &'brr' brr_stmt
 //     | &('class' | '@') class_def
 //     | &('with' | 'async') with_stmt
 //     | &('for' | 'async') for_stmt
@@ -2147,6 +2152,27 @@ compound_stmt_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s compound_stmt[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "&'if' if_stmt"));
+    }
+    { // &'brrr' brrr_stmt
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'brrr' brrr_stmt"));
+        stmt_ty brrr_stmt_var;
+        if (
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 665)  // token='brrr'
+            &&
+            (brrr_stmt_var = brrr_stmt_rule(p))  // brrr_stmt
+        )
+        {
+            D(fprintf(stderr, "%*c+ compound_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "&'brrr' brrr_stmt"));
+            _res = brrr_stmt_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s compound_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "&'brrr' brrr_stmt"));
     }
     { // &('class' | '@') class_def
         if (p->error_indicator) {
@@ -7081,6 +7107,95 @@ try_stmt_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s try_stmt[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'try' &&':' block except_star_block+ else_block? finally_block?"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
+
+// brrr_stmt:
+//     | invalid_brrr_stmt
+//     | 'brrr' &&':' block
+static stmt_ty
+brrr_stmt_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    stmt_ty _res = NULL;
+    int _mark = p->mark;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        p->level--;
+        return NULL;
+    }
+    int _start_lineno = p->tokens[_mark]->lineno;
+    UNUSED(_start_lineno); // Only used by EXTRA macro
+    int _start_col_offset = p->tokens[_mark]->col_offset;
+    UNUSED(_start_col_offset); // Only used by EXTRA macro
+    if (p->call_invalid_rules) { // invalid_brrr_stmt
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> brrr_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_brrr_stmt"));
+        void *invalid_brrr_stmt_var;
+        if (
+            (invalid_brrr_stmt_var = invalid_brrr_stmt_rule(p))  // invalid_brrr_stmt
+        )
+        {
+            D(fprintf(stderr, "%*c+ brrrr_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_brrr_stmt"));
+            _res = invalid_brrr_stmt_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s brrr_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_brrr_stmt"));
+    }
+    { // 'brrr' ':' block
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> brrr_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'brrr' &&':' block"));
+        Token * _keyword;
+        Token * _literal;
+        asdl_stmt_seq* b;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 665))  // token='brrr'
+            &&
+            (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
+            &&
+            (b = block_rule(p))  // block
+        )
+        {
+            D(fprintf(stderr, "%*c+ brrr_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'brrr' &&':' block"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                p->level--;
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = _PyAST_Brrr ( b , EXTRA );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+    D(fprintf(stderr, "%*c%s brrr_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+            p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'brrr' &&':' block"));
     }
     _res = NULL;
   done:
@@ -23962,6 +24077,91 @@ invalid_if_stmt_rule(Parser *p)
     p->level--;
     return _res;
 }
+
+
+// invalid_brrr_stmt:
+//     | 'brrr' ':' NEWLINE
+//     | 'brrr' ':' NEWLINE !INDENT
+static void *
+invalid_brrr_stmt_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // 'brrr' ':' NEWLINE
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_brrr_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'brrr' NEWLINE"));
+        Token * _keyword;
+        Token * _literal;
+        Token * newline_var;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 665))  // token='brrr'
+            &&
+            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
+            &&
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_brrr_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'brrr'':' NEWLINE"));
+            _res = RAISE_SYNTAX_ERROR ( "expected ':'" );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_brrr_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'brrr' ':' NEWLINE"));
+    }
+    { // 'brrr' ':' NEWLINE !INDENT
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_brrr_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'brrr' ':' NEWLINE !INDENT"));
+        Token * _literal;
+        Token * a;
+        Token * newline_var;
+        if (
+            (a = _PyPegen_expect_token(p, 665))  // token='brrr'
+            &&
+            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
+            &&
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
+            &&
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, INDENT)  // token=INDENT
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_brrr_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'brrr' ':' NEWLINE !INDENT"));
+            _res = RAISE_INDENTATION_ERROR ( "expected an indented block after 'brrr' statement on line %d" , a -> lineno );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_brrr_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'brrr' ':' NEWLINE !INDENT"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
 
 // invalid_elif_stmt:
 //     | 'elif' named_expression NEWLINE

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -804,6 +804,9 @@ validate_stmt(struct validator *state, stmt_ty stmt)
             validate_body(state, stmt->v.If.body, "If") &&
             validate_stmts(state, stmt->v.If.orelse);
         break;
+    case Brrr_kind:
+        ret = validate_body(state, stmt->v.Brrr.body, "Brrr");
+        break;
     case With_kind:
         if (!validate_nonempty_seq(stmt->v.With.items, "items", "With"))
             return 0;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -953,6 +953,9 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
         CALL_SEQ(astfold_stmt, stmt, node_->v.If.body);
         CALL_SEQ(astfold_stmt, stmt, node_->v.If.orelse);
         break;
+    case Brrr_kind:
+        CALL_SEQ(astfold_stmt, stmt, node_->v.Brrr.body);
+        break;
     case With_kind:
         CALL_SEQ(astfold_withitem, withitem, node_->v.With.items);
         CALL_SEQ(astfold_stmt, stmt, node_->v.With.body);

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3097,6 +3097,17 @@ compiler_lambda(struct compiler *c, expr_ty e)
 }
 
 static int
+compiler_brrr(struct compiler *c, stmt_ty s)
+{
+    assert(s->kind == Brrr_kind);
+    NEW_JUMP_TARGET_LABEL(c, end);
+    VISIT_SEQ(c, stmt, s->v.Brrr.body);
+    USE_LABEL(c, end);
+    return SUCCESS;
+}
+
+
+static int
 compiler_if(struct compiler *c, stmt_ty s)
 {
     jump_target_label next;
@@ -4080,6 +4091,8 @@ compiler_visit_stmt(struct compiler *c, stmt_ty s)
         return compiler_while(c, s);
     case If_kind:
         return compiler_if(c, s);
+    case Brrr_kind:
+        return compiler_brrr(c, s);
     case Match_kind:
         return compiler_match(c, s);
     case Raise_kind:

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1821,6 +1821,9 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
         if (s->v.If.orelse)
             VISIT_SEQ(st, stmt, s->v.If.orelse);
         break;
+    case Brrr_kind:
+        VISIT_SEQ(st, stmt, s->v.Brrr.body);
+        break;
     case Match_kind:
         VISIT(st, expr, s->v.Match.subject);
         VISIT_SEQ(st, match_case, s->v.Match.cases);


### PR DESCRIPTION
Build Python and then test out the `brrr` statement:

```sh
./configure --enable-optimizations --with-lto
make -s -j
./python  # start the freshly built python repl
```

Inspecting it with `ast.parse`:

```python
>>> x = """
... brrr:
...     print("foo")
... """
>>>
>>> y = x.strip()
>>> print(y)
brrr:
    print("foo")
>>> import ast
>>> ast.parse(y)
<ast.Module object at 0x7ff22f994e70>
>>> ast.parse(y).body
[<ast.Brrr object at 0x7ff22f994d30>]
```

or disassembling it:

```python
>>> import dis
>>> def foo():
...    brrr:
...        print("bar")
>>> dis.dis(foo)
  1           RESUME                   0

  3           LOAD_GLOBAL              1 (print + NULL)
              LOAD_CONST               1 ('bar')
              CALL                     1
              POP_TOP
              RETURN_CONST             0 (None)
```